### PR TITLE
Remove jupyterlab from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 ipywidgets>=7.6.5
-jupyterlab>=3.0.0
 pystac-client>=0.3.0


### PR DESCRIPTION
This requirement caused some installation issues in a managed environment. The code doesn't actually need `jupyterlab` as far as I can tell. My fork is working for me, but may be useful to upstream.